### PR TITLE
Switch to more iso8601 style for data commits

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -20,6 +20,6 @@ jobs:
         git config user.name "Automated"
         git config user.email "actions@users.noreply.github.com"
         git add -A
-        timestamp=$(date -u)
+        timestamp=$(date --utc "+%Y-%m-%d %H:%M:%SZ")
         git commit -m "Latest data: ${timestamp}" || exit 0
         git push


### PR DESCRIPTION
Simon, I think the git scraping idea is super clever and just implemented it for a personal project. Given this is the example repo you point to in your blog post, I thought it would be nice if the reference used a slightly easier to parse date format.

Original: `Fri Oct 1 14:19:30 UTC 2021`
New: `2021-10-01 17:32:06Z`

Have not yet attempted to extract the change data, but I assume it is best to pull the timestamps directly from git, so this is not necessary for parsing. Just squishy humans.

This would break the historical flow of the commits on this repo, so I understand if you reject.